### PR TITLE
feat:created_reset_password

### DIFF
--- a/src/modules/user/controller/index.js
+++ b/src/modules/user/controller/index.js
@@ -81,7 +81,54 @@ async function loginUser(req, res) {
   return res.status(201).send({ statusCode: 'CREATED', token, userEmail });
 }
 
+/**
+ * Resets the password for a given user
+ * 
+ * @param {*} req ExpressRequest
+ * @param {*} res ExpressResponse
+ * @returns {*} success message or error message
+ */
+async function resetPassword(req, res) {
+  const { email, currentPassword, newPassword } = req.body;
+
+  const user = await User.findOne({
+    where: {
+      email
+    }
+  });
+
+  if (!user) {
+    return res.status(400).json({
+      statusCode: 'BAD_REQUEST',
+      errors: {
+        email: [
+          'User not found'
+        ]
+      }
+    });
+  }
+
+  const passwordMatches = await bcrypt.compare(currentPassword, user.password);
+  if (!passwordMatches) {
+    return res.status(400).json({
+      statusCode: 'BAD_REQUEST',
+      errors: {
+        currentPassword: [
+          'Incorrect password'
+        ]
+      }
+    });
+  }
+
+  const newPasswordHash = await bcrypt.hash(newPassword, 10);
+
+  await user.update({ password: newPasswordHash });
+
+  return res.status(200).send({ message: 'Password reset successfully' });
+}
+
 module.exports = {
   registerUser,
-  loginUser
+  loginUser,
+  resetPassword
 };

--- a/src/modules/user/model/index.js
+++ b/src/modules/user/model/index.js
@@ -37,7 +37,7 @@ const registrationSchema = {
   gender: ['required', 'in:MALE,FEMALE'],
   email: ['required', 'string', 'email'],
   username: ['required', 'min:3'],
-  password: ['required', 'string', 'confirmed', 'password_validations'],
+  password: ['required', 'string', 'confirmed', 'password_validtions'],
 };
 
 module.exports = {

--- a/src/modules/user/routes/index.js
+++ b/src/modules/user/routes/index.js
@@ -3,8 +3,9 @@ const express = require('express');
 
 const router = express.Router();
 
-const { registerUser, loginUser } = require('../controller');
+const { registerUser, loginUser, resetPassword } = require('../controller');
 
 router.post('/', registerUser);
 router.post('/login', loginUser);
+router.post('/reset-password', resetPassword);
 module.exports = router;


### PR DESCRIPTION
This PR resets the password

when our users forget their login credentials they can easily reset them through the emails they used while signing up.

To test this manually you can go to the postman 
     - POST request "http://localhost:5000/api/v1/users/reset-password"
     - add the email, current password, and new password fields
    

<img width="856" alt="Screenshot 2023-03-17 120111" src="https://user-images.githubusercontent.com/53978074/225878257-6ff31d06-9f29-4853-b555-b58c051a0cf3.png">

When you use the wrong current credentials

<img width="861" alt="Screenshot 2023-03-17 120440" src="https://user-images.githubusercontent.com/53978074/225878608-b1b41493-8959-403c-952f-c793f2b48afc.png">

When the current password is incorect

<img width="855" alt="image" src="https://user-images.githubusercontent.com/53978074/225879669-270002cb-5ec8-46b7-b868-0fb680785760.png">


