### PR TITLE
Ft mark notification read

### DIFF
--- a/src/modules/notification/controllers/notifications.controller.js
+++ b/src/modules/notification/controllers/notifications.controller.js
@@ -170,6 +170,49 @@ class NotificationsController {
       });
     }
   }
+
+
+  static async markAllNotificationsAsRead(req, res) {
+    try {
+      const userId = req.user.id;
+
+      const notifications = await Notification.findAll({
+        where: { receiverId: userId, read: false }
+      });
+
+      if (notifications.length === 0) {
+        return res.status(500).json({
+          success: false,
+          message: 'User has no unread notifications.',
+        });
+      }
+
+      const [numUpdated, _] = await Notification.update(
+        { read: true },
+        { where: { receiverId: userId, read: false } }
+      );
+
+      if (numUpdated > 0) {
+        return res.status(200).json({
+          success: true,
+          message: 'Notifications marked as read.',
+        });
+      } else {
+        return res.status(500).json({
+          success: false,
+          message: 'No notifications to mark as read.',
+        });
+      }
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({
+        success: false,
+        message: 'An error occurred while marking notifications as read.',
+        error: err.message,
+      });
+    }
+  }
+
 }
 
 module.exports = { NotificationsController };

--- a/src/modules/notification/controllers/notifications.controller.js
+++ b/src/modules/notification/controllers/notifications.controller.js
@@ -171,7 +171,6 @@ class NotificationsController {
     }
   }
 
-
   static async markAllNotificationsAsRead(req, res) {
     try {
       const userId = req.user.id;
@@ -187,7 +186,7 @@ class NotificationsController {
         });
       }
 
-      const [numUpdated, _] = await Notification.update(
+      const [numUpdated] = await Notification.update(
         { read: true },
         { where: { receiverId: userId, read: false } }
       );
@@ -197,12 +196,11 @@ class NotificationsController {
           success: true,
           message: 'Notifications marked as read.',
         });
-      } else {
-        return res.status(500).json({
-          success: false,
-          message: 'No notifications to mark as read.',
-        });
       }
+      return res.status(500).json({
+        success: false,
+        message: 'No notifications to mark as read.',
+      });
     } catch (err) {
       console.error(err);
       return res.status(500).json({
@@ -212,7 +210,6 @@ class NotificationsController {
       });
     }
   }
-
 }
 
 module.exports = { NotificationsController };

--- a/src/modules/notification/routes/index.js
+++ b/src/modules/notification/routes/index.js
@@ -133,7 +133,7 @@ router.get('/', [authenticate], NotificationsController.getAllNotifications);
  *       400:
  *         description: 'Bad Request'
  */
-router.get('/:bookingId', [authenticate], NotificationsController.getNotificationsByBookingId);
+router.get('/booking/:bookingId', [authenticate], NotificationsController.getNotificationsByBookingId);
 
 /**
  * @swagger
@@ -166,7 +166,7 @@ router.get('/:bookingId', [authenticate], NotificationsController.getNotificatio
  *       400:
  *         description: Bad Request
  */
-router.get('/:userId', [authenticate], NotificationsController.getNotificationsByUserId);
+router.get('/user/:userId', [authenticate], NotificationsController.getNotificationsByUserId);
 
 /**
  * @swagger
@@ -203,4 +203,5 @@ router.delete('/:id', [authenticate], NotificationsController.deleteNotification
 
 router.get('/:type/:bookingId', [authenticate, authorize('MANAGER', 'ADMIN')], NotificationsController.getNotificationsByBookingAndType);
 
+router.put('/all/markRead/:userId', [authenticate], NotificationsController.markAllNotificationsAsRead)
 module.exports = router;

--- a/src/modules/notification/routes/index.js
+++ b/src/modules/notification/routes/index.js
@@ -203,5 +203,5 @@ router.delete('/:id', [authenticate], NotificationsController.deleteNotification
 
 router.get('/:type/:bookingId', [authenticate, authorize('MANAGER', 'ADMIN')], NotificationsController.getNotificationsByBookingAndType);
 
-router.put('/all/markRead/:userId', [authenticate], NotificationsController.markAllNotificationsAsRead)
+router.put('/all/markRead/:userId', [authenticate], NotificationsController.markAllNotificationsAsRead);
 module.exports = router;


### PR DESCRIPTION
#### What does this PR do?
##### Allow user to mark all notifications read
#### How should this be manually tested?
##### login, and use a PUT method http://localhost:3000/api/v1/notification/all/markRead/:userId while logged in
#### Any background context you want to provide?
##### NO
#### What are the relevant pivotal tracker/Trello stories?
##### Users should be able to mark all notifications as read
#### Screenshots (if appropriate)
<img width="524" alt="image" src="https://user-images.githubusercontent.com/60257249/235636852-6ed94ac3-f6ae-456f-aafd-05d98834e46d.png">
